### PR TITLE
#3 Adds support for EDL user tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,14 +67,18 @@ machine urs.earthdata.nasa.gov login <LOGIN> password <PASSWORD>
 
 ### Earthdata Login (EDL) User Token Authentication
 
-As an alternative to netrc, a user token may be used. Once an EDL
+As an alternative to `netrc`, a user token may be used. Once an EDL
 account has been created, EDL allows for the creation of user tokens.
 
 See [EDL's User Token Management](https://urs.earthdata.nasa.gov/documentation/for_users/user_token)
-for more information on generating tokens.
+documentation for more information on generating tokens.
 
 The token may be provided to `cmrfetch` via the `--edltoken` flag or the `EDL_TOKEN`
 environment variable.
+
+> **NOTE**: If either `--edltoken` or `EDL_TOKEN` is provided, token auth will take priority
+> over `netrc` (`netrc` login will not be attempted). The `--edltoken` value, if provided,
+> will take priority over the `EDL_TOKEN` environment variable.
 
 ### Authentication Cookies
 

--- a/README.md
+++ b/README.md
@@ -65,6 +65,17 @@ machine urs.earthdata.nasa.gov login <LOGIN> password <PASSWORD>
 > **NOTE**: It is very important to make sure this file is not readable by other
 > users. On linux/osx you can limit permissions like so `chmod 0600 ~/.netrc`
 
+### Earthdata Login (EDL) User Token Authentication
+
+As an alternative to netrc, a user token may be used. Once an EDL
+account has been created, EDL allows for the creation of user tokens.
+
+See [EDL's User Token Management](https://urs.earthdata.nasa.gov/documentation/for_users/user_token)
+for more information on generating tokens.
+
+The token may be provided to `cmrfetch` via the `--edltoken` flag or the `EDL_TOKEN`
+environment variable.
+
 ### Authentication Cookies
 
 `cmrfetch` performs a single login for every instantiation. If you are

--- a/cmd/granules/cmd.go
+++ b/cmd/granules/cmd.go
@@ -82,6 +82,8 @@ NASA Earthdata Authentication
 			return fmt.Errorf("at least one of --collection, --shortname, --nativeid, or --filename is required")
 		}
 
+		token, err := flags.GetString("edltoken")
+		failOnError(err)
 		netrc, err := flags.GetBool("netrc")
 		failOnError(err)
 		verbose, err := flags.GetBool("verbose")
@@ -123,7 +125,7 @@ NASA Earthdata Authentication
 		api := internal.NewCMRSearchAPI(logger)
 
 		if destdir != "" {
-			err = doDownload(context.TODO(), api, params, destdir, netrc, clobber, yes, verbose, concurrency)
+			err = doDownload(context.TODO(), api, params, destdir, token, netrc, clobber, yes, verbose, concurrency)
 		} else {
 			err = do(api, params, output, fields, yes)
 		}
@@ -148,10 +150,14 @@ func init() {
 			"Checksums are verified for all downloaded files, if a checksum is available.")
 	flags.BoolP("download-clobber", "C", false, "Overwrite any existing files when downloading.")
 	flags.Int("download-concurrency", defaultDownloadConcurrency, "Number of concurrent downloads")
+	flags.String("edltoken", "",
+		"Use a NASA EDL token for bearer-based authentication on redirect. Either this or netrc is "+
+			"necessary for NASA Earthdata authentication, which many providers use. See the NASA "+
+			"Earthdata Authentication above.")
 	flags.Bool("netrc", true,
-		"Use netrc for basic authentication credentials on redirect. This is necessary for NASA "+
-			"Earthdata authentication, which many providers use. See the NASA Earthdata Authentication "+
-			"above.")
+		"Use netrc for basic authentication credentials on redirect. Either this or edltoken is "+
+			"necessary for NASA Earthdata authentication, which many providers use. See the NASA "+
+			"Earthdata Authentication above.")
 
 	flags.StringSliceP("nativeid", "N", nil, "granule native id")
 	flags.StringSliceP("collection", "c", nil, "Collection concept id")

--- a/cmd/granules/download.go
+++ b/cmd/granules/download.go
@@ -45,7 +45,7 @@ func doDownload(
 	ctx context.Context,
 	api *internal.CMRSearchAPI,
 	params *internal.SearchGranuleParams,
-	destdir string,
+	destdir, token string,
 	netrc, clobber, yes, verbose bool,
 	concurrency int,
 ) error {
@@ -74,7 +74,7 @@ func doDownload(
 	}
 
 	fetcherFactory := func() (internal.Fetcher, error) {
-		fetcher, err := internal.NewHTTPFetcher(netrc)
+		fetcher, err := internal.NewHTTPFetcher(netrc, token)
 		return fetcher.Fetch, err
 	}
 	destdir, err = filepath.Abs(destdir)

--- a/internal/fetch_http_test.go
+++ b/internal/fetch_http_test.go
@@ -98,7 +98,7 @@ func TestHTTPFetcher(t *testing.T) {
 		}))
 		defer svr.Close()
 
-		fetcher, err := NewHTTPFetcher(true)
+		fetcher, err := NewHTTPFetcher(true, nil)
 		require.NoError(t, err)
 
 		w := bytes.NewBuffer(nil)
@@ -113,7 +113,7 @@ func TestHTTPFetcher(t *testing.T) {
 		}))
 		defer svr.Close()
 
-		fetcher, err := NewHTTPFetcher(true)
+		fetcher, err := NewHTTPFetcher(true, nil)
 		require.NoError(t, err)
 
 		w := bytes.NewBuffer(nil)

--- a/internal/fetch_http_test.go
+++ b/internal/fetch_http_test.go
@@ -98,7 +98,7 @@ func TestHTTPFetcher(t *testing.T) {
 		}))
 		defer svr.Close()
 
-		fetcher, err := NewHTTPFetcher(true, nil)
+		fetcher, err := NewHTTPFetcher(true, "")
 		require.NoError(t, err)
 
 		w := bytes.NewBuffer(nil)
@@ -113,7 +113,7 @@ func TestHTTPFetcher(t *testing.T) {
 		}))
 		defer svr.Close()
 
-		fetcher, err := NewHTTPFetcher(true, nil)
+		fetcher, err := NewHTTPFetcher(true, "")
 		require.NoError(t, err)
 
 		w := bytes.NewBuffer(nil)


### PR DESCRIPTION
This PR adds EDL token functionality, see #3 

The HTTP client's `CheckRedirect` will be set with `newRedirectWithToken` and update the request header with the Bearer authentication token when the `--edltoken` flag is passed or the `EDL_TOKEN` env var is set. If neither is set, `newRedirectWithNetrcCredentials` will be used to set the `CheckRedirect` as before.

Authentication priority notes:
- `--edltoken` will resolve first; `EDL_TOKEN` env var and `netrc` will be ignored
- `EDL_TOKEN` env var will resolve second; `netrc` will be ignored
- `netrc` will resolve third

Example usage with flag:

```
cmrfetch granules -c C1964798938-LAADS -t 2023-04-01,2023-04-01T00:06:00Z --download tmp --edltoken $(cat mytoken)
```

This also resolves the edge case where non-ASIPS netrc downloads cause an error when Organization or other fields are not set in the EDL user profile.