### PR TITLE
Addreses Issue 11 - PREFIRE download fails on missing hash type check

### DIFF
--- a/internal/fetch.go
+++ b/internal/fetch.go
@@ -39,7 +39,7 @@ func newHash(alg string) (hash.Hash, error) {
 	case "sha512", "sha-512":
 		hash = sha512.New()
 	default:
-		return nil, fmt.Errorf("expected one of md5, sha256, sha512, got %s", alg)
+		return nil, fmt.Errorf("WARNING: expected one of md5, sha256, sha512, got %q", alg)
 	}
 	return hash, nil
 }

--- a/internal/fetch.go
+++ b/internal/fetch.go
@@ -39,7 +39,7 @@ func newHash(alg string) (hash.Hash, error) {
 	case "sha512", "sha-512":
 		hash = sha512.New()
 	default:
-		return nil, fmt.Errorf("WARNING: expected one of md5, sha256, sha512, got %q", alg)
+		return nil, fmt.Errorf("expected one of MD5, SHA-256, SHA-512, got %q", alg)
 	}
 	return hash, nil
 }

--- a/internal/fetch.go
+++ b/internal/fetch.go
@@ -34,9 +34,9 @@ func newHash(alg string) (hash.Hash, error) {
 	switch strings.ToLower(alg) {
 	case "md5":
 		hash = md5.New()
-	case "sha256":
+	case "sha256", "sha-256":
 		hash = sha256.New()
-	case "sha512":
+	case "sha512", "sha-512":
 		hash = sha512.New()
 	default:
 		return nil, fmt.Errorf("expected one of md5, sha256, sha512, got %s", alg)

--- a/internal/fetch_test.go
+++ b/internal/fetch_test.go
@@ -21,7 +21,7 @@ func TestSplitChecksum(t *testing.T) {
 }
 
 func Test_newHash(t *testing.T) {
-	goodCases := []string{"md5", "MD5", "sha256", "sha512"}
+	goodCases := []string{"md5", "MD5", "sha256", "SHA-256", "sha512", "SHA-512"}
 	for _, test := range goodCases {
 		t.Run(test, func(t *testing.T) {
 			hash, err := newHash(test)


### PR DESCRIPTION
- "SHA-256" and "SHA-512" hash type strings are now respected in addition to the already-configured "sha256" and "sha512"
- SHA hash type check failure will now result in a logged warning and the file download will proceed